### PR TITLE
Fix Pyright unknown types for YAML.load / YAML.dump (SF #564)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -10,6 +10,9 @@
   this limits the recursion, so loading does throw a `MaxDepthExceededError`.
   Based on comments by Benjamin Oberdorfer via email. This also triggered the
   new documenation section on processing unchecked input.
+- use `typing.TYPE_CHECKING` instead of `if False` for type-only imports in
+  `compat.py` and `main.py`, and annotate `YAML.dump(..., data=...)` with `Any`,
+  so Pyright can resolve `YAML.load` / `YAML.dump` parameter types (SF #564).
 
 [0.18.17, 2025-12-17]:
 - try to load C functions from `_ruamel_yaml_clibz` first.

--- a/compat.py
+++ b/compat.py
@@ -12,7 +12,9 @@ import collections.abc
 
 from ruamel.yaml.docinfo import Version  # NOQA
 # fmt: off
-if False:  # MYPY
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
     from typing import Any, Dict, Optional, List, Union, BinaryIO, IO, Text, Tuple  # NOQA
     from typing import Optional  # NOQA
     try:

--- a/main.py
+++ b/main.py
@@ -35,8 +35,21 @@ from ruamel.yaml.loader import Loader as UnsafeLoader  # NOQA
 from ruamel.yaml.comments import CommentedMap, CommentedSeq, C_PRE
 from ruamel.yaml.docinfo import DocInfo, version, Version
 
-from typing import List, Set, Dict, Tuple, Union, Any, Callable, Optional, Text, Type  # NOQA
-if False:  # MYPY
+from typing import (
+    TYPE_CHECKING,
+    List,
+    Set,
+    Dict,
+    Tuple,
+    Union,
+    Any,
+    Callable,
+    Optional,
+    Text,
+    Type,
+)  # NOQA
+
+if TYPE_CHECKING:
     from ruamel.yaml.compat import StreamType, StreamTextType, VersionType  # NOQA
     from types import TracebackType
     from pathlib import Path
@@ -581,7 +594,11 @@ class YAML:
                 raise
 
     def dump(
-        self: Any, data: Union[Path, StreamType], stream: Any = None, *, transform: Any = None,
+        self,
+        data: Any,
+        stream: Optional[Union[Path, StreamType]] = None,
+        *,
+        transform: Any = None,
     ) -> Any:
         if self._context_manager:
             if not self._output:


### PR DESCRIPTION
## Summary

Fixes [SourceForge #564](https://sourceforge.net/p/ruamel-yaml/tickets/564/): under Pyright strict mode, `YAML.load` and `YAML.dump` reported `reportUnknownMemberType` because `stream` / `data` resolved to `Unknown`.

## Cause

Imports for `Path`, `StreamType`, and `StreamTextType` lived under `if False:  # MYPY`. Pyright does not treat that as a type-checking-only branch (unlike `typing.TYPE_CHECKING`), so those names were undefined and annotation resolution failed.

## Changes

- `compat.py`, `main.py`: use `TYPE_CHECKING` instead of `if False` for MYPY-only imports.
- `YAML.dump`: type `data` as `Any` (the object to serialize). The previous `Union[Path, StreamType]` was incorrect for `data`. `stream` is `Optional[Union[Path, StreamType]]`.

## Verification

Strict Pyright on a small consumer that calls `YAML().load(...)` and `YAML().dump(..., ...)` reports 0 errors.

Made with [Cursor](https://cursor.com)